### PR TITLE
hotfix: cicd in push as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   build-and-test:


### PR DESCRIPTION
머지 상태에서 오류가 나는데, 액션에서 이를 실행하지 않는 버그를 발견했습니다.