### PR TITLE
fix: dotenv provides its own types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/swagger": "^7.2.0",
         "@types/cookie-parser": "^1.4.6",
-        "@types/dotenv": "^8.2.0",
         "@types/passport-google-oauth20": "^2.0.14",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -2222,15 +2221,6 @@
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
-    },
-    "node_modules/@types/dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-ylSC9GhfRH7m1EUXBXofhgx4lUWmFeQDINW5oLuS+gxWdfUeW4zJdeVTYVkexEW+e2VUvlZR2kGnGGipAWR7kw==",
-      "deprecated": "This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "dotenv": "*"
-      }
     },
     "node_modules/@types/eslint": {
       "version": "8.56.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/swagger": "^7.2.0",
     "@types/cookie-parser": "^1.4.6",
-    "@types/dotenv": "^8.2.0",
     "@types/passport-google-oauth20": "^2.0.14",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",


### PR DESCRIPTION
dotenv @types 를 제거합니다. 자체적으로 타입을 지원하기 때문에 필요 없다고 합니다.