### PR TITLE
OAuth + Jwt dto 분리 + 기존 유저와 신규 회원을 롤로 분리

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,6 +18,8 @@ import { AuthSignUpDto } from './auth.dto';
 import { AuthService } from './auth.service';
 import { CustomJwtGuard } from './custom-jwt.guard';
 import { MockSignInDto, signInDtoBodyOptions } from './dto/mock-sign-in.dto';
+import { Role } from './role/role';
+import { Roles } from './role/role.decorator';
 
 @ApiTags('Authorization')
 @Controller('auth')
@@ -91,9 +93,16 @@ export class AuthController {
 
   @ApiOperation({ summary: 'Profile' })
   @UseGuards(CustomJwtGuard)
-  @Get('profile')
+  @Get('/profile')
   @HttpCode(HttpStatus.OK)
   getProfile(@Req() req: Request) {
+    return req.user;
+  }
+
+  @UseGuards(CustomJwtGuard)
+  @Roles(Role.NotYetSignedUp)
+  @Get('/new-user/profile')
+  isNotYetSignedUp(@Req() req: Request) {
     return req.user;
   }
 }

--- a/src/auth/auth.dto.ts
+++ b/src/auth/auth.dto.ts
@@ -1,12 +1,20 @@
 import { IsString } from 'class-validator';
 import { Role } from './role/role';
 
-export class AuthLoginDto {
+export class OAuthUserDto {
   constructor(
     readonly provider: string,
     readonly providerId: string,
     readonly email: string,
   ) {}
+}
+
+export interface JwtUserDto {
+  nickname: string;
+  role: Role;
+  provider: string;
+  providerId: string;
+  email: string;
 }
 
 export class AuthSignUpDto {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -5,7 +5,7 @@ import { Request, Response } from 'express';
 import { isNil } from 'src/common/utils';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
-import { AuthSignUpDto, JwtUserDto, OAuthUserDto } from './auth.dto';
+import { AuthSignUpDto, JwtUserDto } from './auth.dto';
 import { Role } from './role/role';
 
 @Injectable()
@@ -25,7 +25,7 @@ export class AuthService {
     }
 
     try {
-      const payload: OAuthUserDto = await this.jwtService.verifyAsync(token, {
+      const payload: JwtUserDto = await this.jwtService.verifyAsync(token, {
         secret: this.configService.get<string>('JWT_SECRET'),
       });
 
@@ -62,7 +62,7 @@ export class AuthService {
     };
   }
 
-  async makeUser(authLoginDto: OAuthUserDto, authSignUpDto: AuthSignUpDto) {
+  async makeUser(authLoginDto: JwtUserDto, authSignUpDto: AuthSignUpDto) {
     const user = new User();
 
     user.provider = authLoginDto.provider;
@@ -83,7 +83,7 @@ export class AuthService {
 
     const clientUrl = await this.configService.get<string>('CLIENT_URL');
 
-    const { provider, providerId, email } = req.user as OAuthUserDto;
+    const { provider, providerId, email } = req.user as JwtUserDto;
 
     const user = await this.userService.findUserByProviderId(providerId); // TODO: check both provider & providerId
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,51 +1,21 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService, TokenExpiredError } from '@nestjs/jwt';
 import { Request, Response } from 'express';
 import { isNil } from 'src/common/utils';
 import { User } from 'src/user/user.entity';
 import { UserService } from 'src/user/user.service';
-import { AuthLoginDto, AuthSignUpDto } from './auth.dto';
+import { AuthSignUpDto, JwtUserDto, OAuthUserDto } from './auth.dto';
+import { Role } from './role/role';
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
   constructor(
     private readonly userService: UserService,
     private readonly configService: ConfigService,
     private jwtService: JwtService,
   ) {}
-
-  async mockSignIn(
-    username: string,
-    pass: string,
-  ): Promise<{ accessToken: string }> {
-    const user = await this.userService.findOne(username);
-
-    if (isNil(user) || user.password !== pass) {
-      throw new UnauthorizedException();
-    }
-
-    const payload = {
-      sub: user.userId,
-      username: user.username,
-      roles: user.roles,
-    };
-    return {
-      accessToken: await this.jwtService.signAsync(payload),
-    };
-  }
-
-  async tempSignUp(provider: string, providerId: string, email: string) {
-    const payload = {
-      provider: provider,
-      providerId: providerId,
-      email: email,
-    };
-
-    return {
-      tmpToken: await this.jwtService.signAsync(payload),
-    };
-  }
 
   async signUp(req: Request, authSignUpDto: AuthSignUpDto) {
     const [_type, token] = req?.headers?.authorization?.split(' ') ?? [];
@@ -55,7 +25,7 @@ export class AuthService {
     }
 
     try {
-      const payload: AuthLoginDto = await this.jwtService.verifyAsync(token, {
+      const payload: OAuthUserDto = await this.jwtService.verifyAsync(token, {
         secret: this.configService.get<string>('JWT_SECRET'),
       });
 
@@ -76,7 +46,6 @@ export class AuthService {
     }
   }
 
-  // 이름 변경 필요
   async signIn(providerId: string) {
     const user = await this.userService.findUserByProviderId(providerId);
 
@@ -93,7 +62,7 @@ export class AuthService {
     };
   }
 
-  async makeUser(authLoginDto: AuthLoginDto, authSignUpDto: AuthSignUpDto) {
+  async makeUser(authLoginDto: OAuthUserDto, authSignUpDto: AuthSignUpDto) {
     const user = new User();
 
     user.provider = authLoginDto.provider;
@@ -108,33 +77,53 @@ export class AuthService {
   }
 
   async setTokenToCookie(req: Request, res: Response) {
-    if (req.user) {
-      const { provider, providerId, email } = req.user as AuthLoginDto;
-
-      const user = await this.userService.findUserByProviderId(providerId);
-      const clientUrl = await this.configService.get<string>('CLIENT_URL');
-
-      if (user) {
-        const accessToken = (await this.signIn(providerId)).accessToken;
-
-        res.cookie('Authentication', accessToken, {
-          httpOnly: true,
-          secure: false,
-        });
-        res.redirect(`${clientUrl}/login/success`);
-        return;
-      }
-
-      const tmpToken = (await this.tempSignUp(provider, providerId, email))
-        .tmpToken;
-
-      res.cookie('info', tmpToken, {
-        httpOnly: true,
-        secure: false,
-      });
-      res.redirect(`${clientUrl}/login/new-user`);
-      return;
+    if (isNil(req.user)) {
+      throw new UnauthorizedException();
     }
-    return;
+
+    const clientUrl = await this.configService.get<string>('CLIENT_URL');
+
+    const { provider, providerId, email } = req.user as OAuthUserDto;
+
+    const user = await this.userService.findUserByProviderId(providerId); // TODO: check both provider & providerId
+
+    const jwtUser: JwtUserDto = {
+      nickname: user?.nickname || 'new user',
+      provider: provider,
+      providerId: providerId,
+      email: email,
+      role: user?.role ?? Role.NotYetSignedUp,
+    };
+
+    const token = await this.jwtService.signAsync(jwtUser);
+
+    const redirectPath = isNil(user) ? '/login/new-user' : '/login/success';
+    res.cookie('info', token, {
+      httpOnly: true,
+      secure: false,
+    });
+    return res.redirect(`${clientUrl}${redirectPath}`);
+  }
+
+  async mockSignIn(
+    username: string,
+    pass: string,
+  ): Promise<{ accessToken: string }> {
+    const user = await this.userService.findOneMockUser(username);
+
+    if (isNil(user) || user.password !== pass) {
+      throw new UnauthorizedException();
+    }
+
+    const payload: JwtUserDto = {
+      nickname: user.username,
+      provider: 'mock',
+      providerId: '123412341234',
+      email: 'mock@mock.com',
+      role: user.roles[0],
+    };
+    return {
+      accessToken: await this.jwtService.signAsync(payload),
+    };
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -98,7 +98,7 @@ export class AuthService {
     const token = await this.jwtService.signAsync(jwtUser);
 
     const redirectPath = isNil(user) ? '/login/new-user' : '/login/success';
-    res.cookie('info', token, {
+    res.cookie('Authentication', token, {
       httpOnly: true,
       secure: false,
     });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -62,12 +62,12 @@ export class AuthService {
     };
   }
 
-  async makeUser(authLoginDto: JwtUserDto, authSignUpDto: AuthSignUpDto) {
+  async makeUser(jwtUserDto: JwtUserDto, authSignUpDto: AuthSignUpDto) {
     const user = new User();
 
-    user.provider = authLoginDto.provider;
-    user.providerId = authLoginDto.providerId;
-    user.email = authLoginDto.email;
+    user.provider = jwtUserDto.provider;
+    user.providerId = jwtUserDto.providerId;
+    user.email = jwtUserDto.email;
     user.nickname = authSignUpDto.nickname;
     user.gender = authSignUpDto.gender;
     user.job = authSignUpDto.job;

--- a/src/auth/custom-jwt.guard.ts
+++ b/src/auth/custom-jwt.guard.ts
@@ -2,6 +2,7 @@ import {
   CanActivate,
   ExecutionContext,
   Injectable,
+  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -13,6 +14,7 @@ import { JwtUserDto } from './auth.dto';
 
 @Injectable()
 export class CustomJwtGuard implements CanActivate {
+  private readonly logger = new Logger(CustomJwtGuard.name);
   constructor(
     private readonly jwtService: JwtService,
     private readonly reflector: Reflector,
@@ -35,6 +37,7 @@ export class CustomJwtGuard implements CanActivate {
       this.extractTokenFromHeader(request) ?? request.cookies?.Authentication;
 
     if (isNil(token)) {
+      this.logger.debug('Token is missing!');
       throw new UnauthorizedException();
     }
 
@@ -45,8 +48,8 @@ export class CustomJwtGuard implements CanActivate {
 
       request['user'] = payload;
     } catch (e) {
-      console.error('Token is invalid!');
-      console.error(e);
+      this.logger.debug('Token is invalid!');
+      this.logger.debug(e);
 
       throw new UnauthorizedException();
     }

--- a/src/auth/custom-jwt.guard.ts
+++ b/src/auth/custom-jwt.guard.ts
@@ -9,6 +9,7 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { Request } from 'express';
 import { IS_PUBLIC_KEY, isNil } from 'src/common/utils';
+import { JwtUserDto } from './auth.dto';
 
 @Injectable()
 export class CustomJwtGuard implements CanActivate {
@@ -38,7 +39,7 @@ export class CustomJwtGuard implements CanActivate {
     }
 
     try {
-      const payload = await this.jwtService.verifyAsync(token, {
+      const payload: JwtUserDto = await this.jwtService.verifyAsync(token, {
         secret: this.configService.get<string>('JWT_SECRET'),
       });
 

--- a/src/auth/role.guard.ts
+++ b/src/auth/role.guard.ts
@@ -1,5 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { JwtUserDto } from './auth.dto';
 import { ROLES_KEY } from './role/role.decorator';
 
 @Injectable()
@@ -17,7 +18,10 @@ export class RoleGuard implements CanActivate {
     }
 
     const { user } = context.switchToHttp().getRequest();
+    const jwtUser = user as JwtUserDto;
 
-    return requiredRoles.some((role: string) => user.roles?.includes(role));
+    return requiredRoles.some(
+      (role: string) => jwtUser && jwtUser.role === role,
+    );
   }
 }

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,7 +1,7 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-google-oauth20';
-import { AuthLoginDto } from '../auth.dto';
 import { isNil } from 'src/common/utils';
+import { OAuthUserDto } from '../auth.dto';
 
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   constructor() {
@@ -30,7 +30,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       throw new Error('email undefined');
     }
 
-    const user: AuthLoginDto = new AuthLoginDto('google', id, email);
+    const user: OAuthUserDto = new OAuthUserDto('google', id, email);
     return user;
   }
 }

--- a/src/auth/strategies/kakao.strategy.ts
+++ b/src/auth/strategies/kakao.strategy.ts
@@ -1,7 +1,7 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-kakao';
-import { AuthLoginDto } from '../auth.dto';
 import { isNil } from 'src/common/utils';
+import { OAuthUserDto } from '../auth.dto';
 
 export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
   constructor() {
@@ -19,7 +19,7 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
       throw new Error('email undefined');
     }
 
-    const user: AuthLoginDto = new AuthLoginDto('kakao', profile.id, email);
+    const user: OAuthUserDto = new OAuthUserDto('kakao', profile.id, email);
     return user;
   }
 }

--- a/src/auth/strategies/naver.strategy.ts
+++ b/src/auth/strategies/naver.strategy.ts
@@ -1,7 +1,7 @@
 import { PassportStrategy } from '@nestjs/passport';
 import { Profile, Strategy } from 'passport-naver';
-import { AuthLoginDto } from '../auth.dto';
 import { isNil } from 'src/common/utils';
+import { OAuthUserDto } from '../auth.dto';
 
 export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
   constructor() {
@@ -18,7 +18,7 @@ export class NaverStrategy extends PassportStrategy(Strategy, 'naver') {
     if (isNil(email)) {
       throw new Error('email undefined');
     }
-    const user: AuthLoginDto = new AuthLoginDto('naver', profile.id, email);
+    const user: OAuthUserDto = new OAuthUserDto('naver', profile.id, email);
     return user;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -31,7 +31,7 @@ export class UserService {
     },
   ];
 
-  async findOne(username: string): Promise<MockUser | undefined> {
+  async findOneMockUser(username: string): Promise<MockUser | undefined> {
     return this.mockUsers.find((user) => user.username === username);
   }
 


### PR DESCRIPTION
OAuth + Jwt dto 분리해 req.user 에 대한 실수를 방지했습니다.

	- OAuthUserDto, JwtUserDto 를 추가했습니다.

기존 유저와 신규 회원을 token 이름이 아니라 role로 구분합니다. 

