### PR TITLE
Post에 viewCount 지원

### DIFF
--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -40,7 +40,11 @@ export class PostController {
   @Public()
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.postService.findOne(id);
+    const post = this.postService.findOne(id);
+    this.postService.incrementViewCount(id).catch((error) => {
+      throw error;
+    });
+    return post;
   }
 
   @Patch(':id')

--- a/src/post/post.entity.ts
+++ b/src/post/post.entity.ts
@@ -32,6 +32,9 @@ export class Post extends CommonEntity {
   @Column({ type: 'text' })
   content!: string;
 
+  @Column({ type: 'int', default: 0 })
+  viewCount!: number;
+
   @ManyToOne(() => User)
   author!: User;
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -117,4 +117,8 @@ export class PostService {
 
     return this.postRepository.delete(id);
   }
+
+  async incrementViewCount(id: number) {
+    return this.postRepository.increment({ id }, 'viewCount', 1);
+  }
 }


### PR DESCRIPTION
GET /posts/id

를 부를 때마다 viewCount를 오르게 했습니다.

의문점:

1. viewCount는 controller에 넣어야 할지 service에 넣어야 할지?
--> gpt에게 아무리 유도를 해봐도 계속 컨트롤러에 넣으라고 추천

2. 비동기로 조회수를 올리고 싶으면 await를 붙이지 않아야 하는데, Promise returned from incrementViewCount is ignored 에러가 계속 뜨는데 어떻게 해결하시는지?