### PR TITLE
사용자 특정 좋아요와 JWT 가드 로직 개선에 관한 게시물 쿼리 업데이트

### DIFF
--- a/src/auth/custom-jwt.guard.ts
+++ b/src/auth/custom-jwt.guard.ts
@@ -29,16 +29,16 @@ export class CustomJwtGuard implements CanActivate {
       context.getClass(),
     ]);
 
-    if (isPublic) {
-      return true;
-    }
-
     const request = context.switchToHttp().getRequest();
 
     const token =
       this.extractTokenFromHeader(request) ?? request.cookies?.Authentication;
 
     if (isNil(token)) {
+      if (isPublic) {
+        return true;
+      }
+
       this.logger.debug('Token is missing!');
       throw new UnauthorizedException();
     }
@@ -50,6 +50,10 @@ export class CustomJwtGuard implements CanActivate {
 
       request.user = payload;
     } catch (e) {
+      if (isPublic) {
+        return true;
+      }
+
       this.logger.debug('Token is invalid!');
       this.logger.debug(e);
 

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -34,7 +34,7 @@ export class PostController {
 
   @Public()
   @Get()
-  find(
+  findRecent(
     @Req() req: Request,
     @Query('page') page: number = 1,
     @Query('limit') limit: number = 10,
@@ -42,7 +42,7 @@ export class PostController {
     const maxLimit = limit > 30 ? 30 : limit;
 
     if (isNil(req.user)) {
-      return this.postService.find(page, maxLimit);
+      return this.postService.findRecent(page, maxLimit);
     }
 
     const jwtUserDto = req.user as JwtUserDto;

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -14,7 +14,9 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
+import { JwtUserDto } from 'src/auth/dto/jwt-user.dto';
 import { Public } from 'src/auth/role/public.decorator';
+import { isNil } from 'src/common/utils';
 import { UpdatePostDto } from 'src/post/dto/update-post.dto';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostService } from './post.service';
@@ -32,9 +34,20 @@ export class PostController {
 
   @Public()
   @Get()
-  find(@Query('page') page: number = 1, @Query('limit') limit: number = 10) {
+  find(
+    @Req() req: Request,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+  ) {
     const maxLimit = limit > 30 ? 30 : limit;
-    return this.postService.find(page, maxLimit);
+
+    if (isNil(req.user)) {
+      return this.postService.find(page, maxLimit);
+    }
+
+    const jwtUserDto = req.user as JwtUserDto;
+    const userId = jwtUserDto?.id ?? undefined;
+    return this.postService.findRecentWithLikes(page, maxLimit, userId);
   }
 
   @Public()

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -83,7 +83,7 @@ export class PostService {
     return { data: postsWithLikes, count };
   }
 
-  async find(page: number, limit: number) {
+  async findRecent(page: number, limit: number) {
     const [data, count] = await this.postRepository.findAndCount({
       skip: (page - 1) * limit,
       take: limit,

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -5,7 +5,7 @@ import { JwtUserDto } from 'src/auth/dto/jwt-user.dto';
 import { isNil } from 'src/common/utils';
 import { UpdatePostDto } from 'src/post/dto/update-post.dto';
 import { UserService } from 'src/user/user.service';
-import { Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 
 import { CreatePostDto } from './dto/create-post.dto';
 
@@ -17,6 +17,7 @@ export class PostService {
     @InjectRepository(Post)
     private readonly postRepository: Repository<Post>,
     private readonly userService: UserService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(req: Request, postCreateDto: CreatePostDto) {
@@ -44,6 +45,42 @@ export class PostService {
     post.content = postCreateDto.content;
     post.author = author;
     return this.postRepository.save(post);
+  }
+
+  /**
+   * Retrieves a paginated list of the most recent posts, including information about whether each post has been liked by a specific user.
+   *
+   * @param page The current page number for pagination. The first page is 1.
+   * @param limit The number of posts to return per page. Helps in controlling the size of data returned.
+   * @param userId The ID of the user for whom the 'like' status of each post is being checked. This ID is used to determine if the user has liked each post.
+   */
+  async findRecentWithLikes(page: number, limit: number, userId: number) {
+    const [data, count] = await this.postRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+
+    const postIds = data.map((post) => post.id);
+
+    const userLikes = await this.dataSource.getRepository('like').find({
+      where: {
+        post: { id: In(postIds) },
+        user: { id: userId },
+      },
+      relations: ['post'],
+    });
+
+    const likedPostIds = new Set(userLikes.map((like) => like.post.id));
+
+    const postsWithLikes = data.map((post) => ({
+      ...post,
+      isLiked: likedPostIds.has(post.id),
+    }));
+
+    return { data: postsWithLikes, count };
   }
 
   async find(page: number, limit: number) {


### PR DESCRIPTION
이번 업데이트는 Post 모듈과 인증 처리에 중요한 변경사항을 도입했습니다. 

### CustomJwtGuard

CustomJwtGuard에서기존에는 Public 을 보기만 하면 바로 true를 반환했지만

이러면 로그인된 유저가 Public 에 접근할 경우 유저의 정체를 알 수 없다는 단점이 있습니다.

즉, `req.user == null` 이라는 단점이 있습니다.

따라서 이제는 우선은 토큰의 부재, 혹은 invalidity를 확인한 후 공개 경로에 대한 접근을 확인하는 방식으로 공개 라우트 처리 로직을 개선했습니다. 

### PostService

2. 한편 Post 모듈에서는 PostService에 `findRecentWithLikes`라는 새로운 메서드가 추가되었습니다. 이 메서드는 각 게시물이 현재 인증된 사용자에 의해 좋아요 되었는지에 대한 정보를 포함하여 게시물 쿼리 기능을 향상시킵니다. 

- 유저가 로그인되지 않았을 경우 `postService.findRecent`
- 유저가 로그인되었을 경우 `postService.findRecentWithLikes`
  - 좋아했을 경우 `isLiked: true` 아닐 경우 `false`
