### PR TITLE
100 comment now includes parent id

### DIFF
--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -17,7 +17,20 @@ export class CommentService {
       where: {
         post: { id: postId },
       },
-      relations: ['user'],
+      relations: ['user', 'parent'],
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        updatedAt: true,
+        user: {
+          id: true,
+          nickname: true,
+        },
+        parent: {
+          id: true,
+        },
+      },
     });
   }
 

--- a/src/comment/entities/comment.entity.ts
+++ b/src/comment/entities/comment.entity.ts
@@ -1,9 +1,10 @@
 import { Post } from 'src/post/post.entity';
 import { User } from 'src/user/user.entity';
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { CommonEntity } from 'src/common/common.entity';
 
 @Entity()
-export class Comment {
+export class Comment extends CommonEntity {
   @PrimaryGeneratedColumn()
   id!: number;
 


### PR DESCRIPTION
코멘트가 부모의 아이디를 포함합니다.

그 외: 코멘트 엔티티가 생성된 날짜와 업데이트된 날짜까지 포함합니다.
