### PR TITLE
118 popular posts api

### DIFF
--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -46,6 +46,12 @@ export class PostController {
     );
   }
 
+  @Public()
+  @Get('/popular')
+  findPopular() {
+    return this.postService.findPopular();
+  }
+
   @Post()
   @HttpCode(HttpStatus.CREATED)
   create(@Req() req: Request, @Body() postCreateDto: CreatePostDto) {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -6,9 +6,7 @@ import { isNil } from 'src/common/utils';
 import { UpdatePostDto } from 'src/post/dto/update-post.dto';
 import { UserService } from 'src/user/user.service';
 
-import { DataSource, MoreThanOrEqual, Repository } from 'typeorm';
-import { Repository } from 'typeorm';
-
+import { MoreThanOrEqual, Repository } from 'typeorm';
 
 import { PostQueryFilter } from 'src/post/post-query-filter';
 import { CreatePostDto } from './dto/create-post.dto';

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -5,7 +5,7 @@ import { JwtUserDto } from 'src/auth/dto/jwt-user.dto';
 import { isNil } from 'src/common/utils';
 import { UpdatePostDto } from 'src/post/dto/update-post.dto';
 import { UserService } from 'src/user/user.service';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { CreatePostDto } from './dto/create-post.dto';
 
@@ -45,6 +45,28 @@ export class PostService {
     post.content = postCreateDto.content;
     post.author = author;
     return this.postRepository.save(post);
+  }
+
+  /** 10 Popular Posts (via viewCount) in the last 7 days
+   */
+  async findPopular() {
+    const today = new Date();
+
+    const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    const [data, count] = await this.postRepository.findAndCount({
+      where: {
+        createdAt: MoreThanOrEqual(lastWeek),
+        viewCount: MoreThanOrEqual(50),
+      },
+      take: 10,
+      relations: ['author'],
+      order: {
+        viewCount: 'DESC',
+      },
+    });
+
+    return { data, count };
   }
 
   async findRecentWithAuthorCommentLikes(


### PR DESCRIPTION
인기글 조회 api입니다. 

최근 일주일 동안
조회수 50이상의 글들 중
조회수 순으로 10개를 추려서 리턴합니다.

GET /posts/popular 로 조회하실 수 있습니다.