### PR TITLE
fix(comment): could not update nor delete comment due to swapped parameters

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -47,7 +47,11 @@ export class PostCommentController {
     @Body() updateCommentDto: UpdateCommentDto,
   ) {
     const jwtUserDto = req.user as JwtUserDto;
-    return this.commentService.update(updateCommentDto, id, jwtUserDto.id);
+    return this.commentService.update({
+      updateCommentDto,
+      commentId: id,
+      userId: jwtUserDto.id,
+    });
   }
 
   @Delete(':id')
@@ -58,6 +62,9 @@ export class PostCommentController {
   ) {
     const jwtUserDto = req.user as JwtUserDto;
 
-    return this.commentService.remove(id, jwtUserDto.id);
+    return this.commentService.remove({
+      commentId: id,
+      userId: jwtUserDto.id,
+    });
   }
 }

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -48,11 +48,15 @@ export class CommentService {
     return this.commentRepository.save(comment);
   }
 
-  async update(
-    updateCommentDto: UpdateCommentDto,
-    userId: number,
-    commentId: number,
-  ) {
+  async update({
+    updateCommentDto,
+    userId,
+    commentId,
+  }: {
+    updateCommentDto: UpdateCommentDto;
+    userId: number;
+    commentId: number;
+  }) {
     const comment = await this.commentRepository.findOneBy({
       id: commentId,
       user: { id: userId },
@@ -69,7 +73,7 @@ export class CommentService {
     return this.commentRepository.save(comment);
   }
 
-  async remove(userId: number, commentId: number) {
+  async remove({ commentId, userId }: { commentId: number; userId: number }) {
     const comment = await this.commentRepository.findOneBy({
       id: commentId,
       user: { id: userId },

--- a/src/common/filters/all-exceptions.filter.ts
+++ b/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,47 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+
+@Catch() // This makes it a global filter, catching all types of exceptions
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message =
+      exception instanceof HttpException
+        ? exception.getResponse()
+        : 'Internal server error';
+
+    this.logger.debug(
+      `Http status: ${status} Error message: ${JSON.stringify(message)}`,
+    );
+
+    this.logger.error(exception);
+    this.logger.error(JSON.stringify(exception));
+
+    if (exception instanceof Error) {
+      this.logger.error(exception.stack);
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      message,
+    });
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { NestFactory } from '@nestjs/core';
 import { SwaggerModule } from '@nestjs/swagger';
 import * as dotenv from 'dotenv';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 import { morganSetup } from './common/morgan/morgan.setup';
 import { BaseAPIDocument } from './config/swagger.documents';
 
@@ -26,6 +27,8 @@ async function bootstrap() {
   if (process.env.NODE_ENV === 'development') {
     morganSetup(app);
   }
+
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   const config = new BaseAPIDocument().initializeOptions();
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
댓글 수정 삭제가 이제 정상 동작합니다.

원인: 뒤바뀐 함수 파라미터 순서

해결책: 앞으로 Unpacking properties from objects passed as a function parameter 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment

이걸 사용해서 같은 실수를 방지합니다.